### PR TITLE
Use hard deletes for removable entities

### DIFF
--- a/src/application/errors/errors.go
+++ b/src/application/errors/errors.go
@@ -18,6 +18,13 @@ func IsUniqueViolation(err error) bool {
 	return false
 }
 
+func IsForeignKeyViolation(err error) bool {
+	if pqErr, ok := err.(*pq.Error); ok {
+		return pqErr.Code == "23503"
+	}
+	return false
+}
+
 func IsNoRowsFinded(err error) bool {
 	return strings.Contains(err.Error(), "no rows in result set")
 }

--- a/src/application/errors/errors_test.go
+++ b/src/application/errors/errors_test.go
@@ -24,6 +24,16 @@ func TestIsUniqueViolation(t *testing.T) {
 	}
 }
 
+func TestIsForeignKeyViolation(t *testing.T) {
+	pqErr := &pq.Error{Code: "23503"}
+	if !IsForeignKeyViolation(pqErr) {
+		t.Fatalf("expected true for foreign key violation")
+	}
+	if IsForeignKeyViolation(stdErrors.New("other")) {
+		t.Fatalf("expected false for non pq error")
+	}
+}
+
 func TestIsNoRowsFinded(t *testing.T) {
 	if !IsNoRowsFinded(stdErrors.New("no rows in result set")) {
 		t.Fatalf("expected true")

--- a/src/infrastructure/repository/customer_repository.go
+++ b/src/infrastructure/repository/customer_repository.go
@@ -10,11 +10,11 @@ import (
 )
 
 type CustomerRepository interface {
-    GetById(ctx context.Context, id int64) (domain.Customer, error)
-    GetAll(ctx context.Context) ([]domain.Customer, error)
-    Create(ctx context.Context, customer domain.Customer) (int64, error)
-    Edit(ctx context.Context, customer domain.Customer, id int64) (int64, error)
-    Inactivate(ctx context.Context, id int64) error
+	GetById(ctx context.Context, id int64) (domain.Customer, error)
+	GetAll(ctx context.Context) ([]domain.Customer, error)
+	Create(ctx context.Context, customer domain.Customer) (int64, error)
+	Edit(ctx context.Context, customer domain.Customer, id int64) (int64, error)
+	Inactivate(ctx context.Context, id int64) error
 }
 
 type customerRepository struct {
@@ -22,18 +22,18 @@ type customerRepository struct {
 }
 
 func NewCustomerRepository(db *sql.DB) CustomerRepository {
-    return &customerRepository{db}
+	return &customerRepository{db}
 }
 
 func (r *customerRepository) Create(ctx context.Context, customer domain.Customer) (int64, error) {
-    var insertedID int64
-    tenantId := ctx.Value(constants.TENANT_KEY)
-    query := `INSERT INTO customers (name, phone_number, tenant_id) VALUES ($1, $2, $3) RETURNING id`
-    err := r.db.QueryRowContext(ctx, query, customer.Name, customer.PhoneNumber, tenantId).Scan(&insertedID)
-    if err != nil {
-        return insertedID, err
-    }
-    return insertedID, nil
+	var insertedID int64
+	tenantId := ctx.Value(constants.TENANT_KEY)
+	query := `INSERT INTO customers (name, phone_number, tenant_id) VALUES ($1, $2, $3) RETURNING id`
+	err := r.db.QueryRowContext(ctx, query, customer.Name, customer.PhoneNumber, tenantId).Scan(&insertedID)
+	if err != nil {
+		return insertedID, err
+	}
+	return insertedID, nil
 }
 
 func (r *customerRepository) GetById(ctx context.Context, id int64) (domain.Customer, error) {
@@ -74,22 +74,39 @@ func (r *customerRepository) GetAll(ctx context.Context) ([]domain.Customer, err
 }
 
 func (r *customerRepository) Edit(ctx context.Context, customer domain.Customer, id int64) (int64, error) {
-    tenantId := ctx.Value(constants.TENANT_KEY)
-    var updatedID int64
+	tenantId := ctx.Value(constants.TENANT_KEY)
+	var updatedID int64
 
-    query := `UPDATE customers SET name = $1, phone_number = $2 WHERE id = $3 AND tenant_id = $4 AND deleted_at IS NULL RETURNING id`
-    err := r.db.QueryRowContext(ctx, query, customer.Name, customer.PhoneNumber, id, tenantId).Scan(&updatedID)
-    if err != nil {
-        if errors.IsNoRowsFinded(err) {
-            return updatedID, errors.New("Cliente não encontrado")
-        }
-        return updatedID, err
-    }
-    return updatedID, nil
+	query := `UPDATE customers SET name = $1, phone_number = $2 WHERE id = $3 AND tenant_id = $4 AND deleted_at IS NULL RETURNING id`
+	err := r.db.QueryRowContext(ctx, query, customer.Name, customer.PhoneNumber, id, tenantId).Scan(&updatedID)
+	if err != nil {
+		if errors.IsNoRowsFinded(err) {
+			return updatedID, errors.New("Cliente não encontrado")
+		}
+		return updatedID, err
+	}
+	return updatedID, nil
 }
 
 func (r *customerRepository) Inactivate(ctx context.Context, id int64) error {
-    query := `UPDATE customers SET deleted_at = now() WHERE id = $1 AND tenant_id = $2`
-    _, err := r.db.ExecContext(ctx, query, id, ctx.Value(constants.TENANT_KEY))
-    return err
+	tenantId := ctx.Value(constants.TENANT_KEY)
+	query := `DELETE FROM customers WHERE id = $1 AND tenant_id = $2`
+	result, err := r.db.ExecContext(ctx, query, id, tenantId)
+	if err != nil {
+		if errors.IsForeignKeyViolation(err) {
+			return errors.New("Não é possível deletar o cliente pois existem registros associados.")
+		}
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return errors.New("Cliente não encontrado")
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- add a helper to identify foreign key violations
- switch delete endpoints to issue hard deletes and surface friendly errors when removal is blocked

## Testing
- go test ./src/application/errors

------
https://chatgpt.com/codex/tasks/task_e_68f38b381c44832b9f6109b021772df4