### PR TITLE
Adjust cash payment status for informed dates

### DIFF
--- a/src/application/service/sales_service.go
+++ b/src/application/service/sales_service.go
@@ -61,6 +61,7 @@ func (s *salesService) CreateSales(ctx context.Context, request request.CreateSa
 			installmentQuantity = *payment.InstallmentsQuantity
 		}
 		installmentsValue := s.calculateTotalValue(payment.Value, installmentQuantity)
+		dateInformed := payment.FirstInstallmentDate != nil
 		for i := 0; i < installmentQuantity; i++ {
 			dueDate := time.Now()
 			if payment.FirstInstallmentDate != nil {
@@ -70,6 +71,7 @@ func (s *salesService) CreateSales(ctx context.Context, request request.CreateSa
 				DueDate:           dueDate.AddDate(0, i, 0),
 				InstallmentNumber: i + 1,
 				InstallmentValue:  installmentsValue[i],
+				DateInformed:      dateInformed,
 			})
 		}
 		payments = append(payments, sales_usecase.DoSalePaymentsInput{

--- a/src/application/usecase/sales_usecase/do_sale.go
+++ b/src/application/usecase/sales_usecase/do_sale.go
@@ -137,7 +137,7 @@ func (s *salesUseCase) createSale(user domain.User, customer domain.Customer, in
 	for i, payment := range paymentsInput {
 		payments[i] = domain.NewSalesPayment(payment.PaymentType)
 		for _, date := range payment.Dates {
-			payments[i].AppendNewSalesDate(date.DueDate, date.InstallmentNumber, date.InstallmentValue)
+			payments[i].AppendNewSalesDate(date.DueDate, date.InstallmentNumber, date.InstallmentValue, date.DateInformed)
 		}
 	}
 	return domain.NewSales(time.Now(), user, customer, items, payments)

--- a/src/application/usecase/sales_usecase/input.go
+++ b/src/application/usecase/sales_usecase/input.go
@@ -31,4 +31,5 @@ type DoSalePaymentDatesInput struct {
 	InstallmentNumber int
 	InstallmentValue  float64
 	Status            domain.PaymentStatus
+	DateInformed      bool
 }

--- a/src/application/usecase/sales_usecase/sales_usecase_test.go
+++ b/src/application/usecase/sales_usecase/sales_usecase_test.go
@@ -338,6 +338,7 @@ func newSaleTestEnv(t *testing.T) saleTestEnv {
 				DueDate:           time.Now().Add(24 * time.Hour),
 				InstallmentNumber: 1,
 				InstallmentValue:  20,
+				DateInformed:      false,
 			}},
 		}},
 	}
@@ -598,6 +599,7 @@ func TestSalesUseCaseCreateSale(t *testing.T) {
 			DueDate:           due,
 			InstallmentNumber: 1,
 			InstallmentValue:  20,
+			DateInformed:      false,
 		}},
 	}}
 

--- a/src/domain/sales.go
+++ b/src/domain/sales.go
@@ -218,13 +218,13 @@ func (s *SalesPayment) isPaymentDatesDuplicated() bool {
 	return false
 }
 
-func (s *SalesPayment) AppendNewSalesDate(dueDate time.Time, installmentNumber int, installmentValue float64) {
+func (s *SalesPayment) AppendNewSalesDate(dueDate time.Time, installmentNumber int, installmentValue float64, dateInformed bool) {
 	newDate := NewSalesPaymentDates(dueDate, nil, installmentNumber, installmentValue, "")
 	newDate.PaymentType = s.PaymentType
 	if s.shouldConfirmPayment() {
 		newDate.Status = PaymentStatusPending
 	} else if s.PaymentType == PaymentTypeCash || s.PaymentType == PaymentTypePix {
-		if isSameDay(dueDate, time.Now()) {
+		if dateInformed && isSameDay(dueDate, time.Now()) {
 			paidDate := dueDate
 			newDate.PaidDate = &paidDate
 			newDate.Status = PaymentStatusPaid

--- a/src/domain/sales_test.go
+++ b/src/domain/sales_test.go
@@ -146,7 +146,7 @@ func TestSalesPaymentDatesDuplicated(t *testing.T) {
 func TestSalesPaymentAppendNewSalesDate(t *testing.T) {
 	payment := NewSalesPayment(PaymentTypeCreditStore)
 	due := time.Now().Add(48 * time.Hour)
-	payment.AppendNewSalesDate(due, 1, 10)
+	payment.AppendNewSalesDate(due, 1, 10, false)
 
 	if len(payment.Dates) != 1 {
 		t.Fatalf("expected one payment date")
@@ -162,7 +162,7 @@ func TestSalesPaymentAppendNewSalesDate(t *testing.T) {
 func TestSalesPaymentAppendNewSalesDateCashFuture(t *testing.T) {
 	payment := NewSalesPayment(PaymentTypeCash)
 	due := time.Now().Add(48 * time.Hour)
-	payment.AppendNewSalesDate(due, 1, 10)
+	payment.AppendNewSalesDate(due, 1, 10, false)
 
 	if len(payment.Dates) != 1 {
 		t.Fatalf("expected one payment date")
@@ -172,10 +172,10 @@ func TestSalesPaymentAppendNewSalesDateCashFuture(t *testing.T) {
 	}
 }
 
-func TestSalesPaymentAppendNewSalesDateCashSameDay(t *testing.T) {
+func TestSalesPaymentAppendNewSalesDateCashSameDayWithDateInformed(t *testing.T) {
 	payment := NewSalesPayment(PaymentTypeCash)
 	due := time.Now()
-	payment.AppendNewSalesDate(due, 1, 10)
+	payment.AppendNewSalesDate(due, 1, 10, true)
 
 	if len(payment.Dates) != 1 {
 		t.Fatalf("expected one payment date")
@@ -185,6 +185,19 @@ func TestSalesPaymentAppendNewSalesDateCashSameDay(t *testing.T) {
 	}
 	if !payment.Dates[0].DueDate.Equal(*payment.Dates[0].PaidDate) {
 		t.Fatalf("expected due date to match paid date")
+	}
+}
+
+func TestSalesPaymentAppendNewSalesDateCashSameDayWithoutDateInformed(t *testing.T) {
+	payment := NewSalesPayment(PaymentTypeCash)
+	due := time.Now()
+	payment.AppendNewSalesDate(due, 1, 10, false)
+
+	if len(payment.Dates) != 1 {
+		t.Fatalf("expected one payment date")
+	}
+	if payment.Dates[0].Status != PaymentStatusPending || payment.Dates[0].PaidDate != nil {
+		t.Fatalf("expected pending status without informed date for cash on same day: %+v", payment.Dates[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- track when payment dates are provided on sale creation requests
- ensure cash and pix installments are only auto-marked as paid when the informed date matches today
- update unit tests to cover pending and paid scenarios for cash sales

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f8e195177c832b91e57a0bb27ac005