### PR TITLE
Mark credit store first installment as paid when due today

### DIFF
--- a/src/domain/sales.go
+++ b/src/domain/sales.go
@@ -222,7 +222,13 @@ func (s *SalesPayment) AppendNewSalesDate(dueDate time.Time, installmentNumber i
 	newDate := NewSalesPaymentDates(dueDate, nil, installmentNumber, installmentValue, "")
 	newDate.PaymentType = s.PaymentType
 	if s.shouldConfirmPayment() {
-		newDate.Status = PaymentStatusPending
+		if installmentNumber == 1 && isSameDay(dueDate, time.Now()) {
+			paidDate := dueDate
+			newDate.PaidDate = &paidDate
+			newDate.Status = PaymentStatusPaid
+		} else {
+			newDate.Status = PaymentStatusPending
+		}
 	} else if s.PaymentType == PaymentTypeCash || s.PaymentType == PaymentTypePix {
 		if dateInformed && isSameDay(dueDate, time.Now()) {
 			paidDate := dueDate

--- a/src/domain/sales_test.go
+++ b/src/domain/sales_test.go
@@ -159,6 +159,28 @@ func TestSalesPaymentAppendNewSalesDate(t *testing.T) {
 	}
 }
 
+func TestSalesPaymentAppendNewSalesDateCreditStoreFirstInstallmentPaidWhenDueToday(t *testing.T) {
+	payment := NewSalesPayment(PaymentTypeCreditStore)
+	due := time.Now()
+	payment.AppendNewSalesDate(due, 1, 10, false)
+
+	if len(payment.Dates) != 1 {
+		t.Fatalf("expected one payment date")
+	}
+	if payment.Dates[0].Status != PaymentStatusPaid {
+		t.Fatalf("expected paid status for first installment due today: %+v", payment.Dates[0])
+	}
+	if payment.Dates[0].PaidDate == nil {
+		t.Fatalf("expected paid date for first installment due today")
+	}
+	if !isSameDay(*payment.Dates[0].PaidDate, time.Now()) {
+		t.Fatalf("expected paid date to be today")
+	}
+	if !payment.Dates[0].DueDate.Equal(*payment.Dates[0].PaidDate) {
+		t.Fatalf("expected due date to match paid date")
+	}
+}
+
 func TestSalesPaymentAppendNewSalesDateCashFuture(t *testing.T) {
 	payment := NewSalesPayment(PaymentTypeCash)
 	due := time.Now().Add(48 * time.Hour)


### PR DESCRIPTION
## Summary
- mark the first credit store installment as paid when its due date matches the current day
- persist the paid date and cover the behavior with a dedicated domain test

## Testing
- go test ./src/domain -count=1


------
https://chatgpt.com/codex/tasks/task_e_68f93ae4284c832b94192e8d1b239b6a