### PR TITLE
Add inventory summary endpoint

### DIFF
--- a/src/api/controllers/inventory_controller.go
+++ b/src/api/controllers/inventory_controller.go
@@ -90,3 +90,17 @@ func (c *InventoryController) GetAllInventories(context echo.Context) error {
 
 	return context.JSON(_http.StatusOK, inventoryViewModels)
 }
+
+func (c *InventoryController) GetInventoriesSummary(context echo.Context) error {
+	summaries, err := c.inventoryService.GetInventoriesSummary(context.Request().Context())
+	if err != nil {
+		return context.JSON(_http.StatusBadRequest, http.HandleError(err))
+	}
+
+	summaryViewModels := make([]viewmodel.GetInventorySummaryViewModel, 0, len(summaries))
+	for _, summary := range summaries {
+		summaryViewModels = append(summaryViewModels, viewmodel.ToGetInventorySummaryViewModel(summary))
+	}
+
+	return context.JSON(_http.StatusOK, summaryViewModels)
+}

--- a/src/api/router.go
+++ b/src/api/router.go
@@ -91,6 +91,7 @@ func (r *router) setupPrivateRoutes() {
 
 	inventoryGroup := private.Group("/inventory", middleware.RoleMiddleware([]domain.Role{domain.UserRoleAdmin}))
 	inventoryGroup.GET("", r.controller.InventoryController.GetAllInventories)
+	inventoryGroup.GET("/summary", r.controller.InventoryController.GetInventoriesSummary)
 	inventoryGroup.GET("/:id/items", r.controller.InventoryController.GetInventoryItemsByInventoryId)
 	inventoryGroup.GET("/items", r.controller.InventoryController.GetAllInventoryItems)
 	inventoryGroup.GET("/transaction", r.controller.InventoryController.GetAllInventoryTransactions)

--- a/src/api/viewmodel/inventory_viewmodel.go
+++ b/src/api/viewmodel/inventory_viewmodel.go
@@ -142,3 +142,24 @@ func ToGetInventoriesViewModel(inventory domain.Inventory) GetInventoriesViewMod
 		Type: inventoryType,
 	}
 }
+
+type GetInventorySummaryViewModel struct {
+	InventoryName     string  `json:"inventory_name"`
+	TotalSkus         int64   `json:"total_skus"`
+	TotalQuantity     float64 `json:"total_quantity"`
+	ZeroQuantityItems int64   `json:"zero_quantity_items"`
+}
+
+func ToGetInventorySummaryViewModel(summary output.GetInventorySummaryOutput) GetInventorySummaryViewModel {
+	inventoryName := inventoryTypeMap[summary.InventoryType]
+	if summary.InventoryUserName != nil && *summary.InventoryUserName != "" {
+		inventoryName = *summary.InventoryUserName + " - " + inventoryName
+	}
+
+	return GetInventorySummaryViewModel{
+		InventoryName:     inventoryName,
+		TotalSkus:         summary.TotalSkus,
+		TotalQuantity:     summary.TotalQuantity,
+		ZeroQuantityItems: summary.ZeroQuantityItems,
+	}
+}

--- a/src/application/service/inventory_service.go
+++ b/src/application/service/inventory_service.go
@@ -21,6 +21,7 @@ type InventoryService interface {
 	GetInventoryItemsByInventoryId(ctx context.Context, id int64) ([]output.GetInventoryItemsOutput, error)
 	GetAllInventoryTransactions(ctx context.Context) ([]output.GetInventoryTransactionsOutput, error)
 	GetAllInventories(ctx context.Context) ([]domain.Inventory, error)
+	GetInventoriesSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error)
 }
 
 type inventoryService struct {
@@ -92,4 +93,8 @@ func (s *inventoryService) GetAllInventoryTransactions(ctx context.Context) ([]o
 
 func (s *inventoryService) GetAllInventories(ctx context.Context) ([]domain.Inventory, error) {
 	return s.inventoryRepository.GetAll(ctx)
+}
+
+func (s *inventoryService) GetInventoriesSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error) {
+	return s.inventoryRepository.GetSummary(ctx)
 }

--- a/src/application/service/inventory_service_test.go
+++ b/src/application/service/inventory_service_test.go
@@ -67,6 +67,16 @@ func TestInventoryServiceGetInventories(t *testing.T) {
 	}
 }
 
+func TestInventoryServiceGetInventoriesSummary(t *testing.T) {
+	repo := &stubInventoryRepository{getSummary: []output.GetInventorySummaryOutput{{}}}
+	service := &inventoryService{inventoryRepository: repo}
+
+	summaries, err := service.GetInventoriesSummary(context.Background())
+	if err != nil || len(summaries) != 1 {
+		t.Fatalf("unexpected summary result")
+	}
+}
+
 func TestInventoryServiceDoTransactionValidationError(t *testing.T) {
 	service := &inventoryService{}
 	if err := service.DoTransaction(context.Background(), request.CreateInventoryTransactionRequest{}); err == nil {

--- a/src/application/service/output/inventory_output.go
+++ b/src/application/service/output/inventory_output.go
@@ -34,3 +34,12 @@ type GetInventoryTransactionsOutput struct {
 	UserDestinationName      *string
 	Justification            *string
 }
+
+type GetInventorySummaryOutput struct {
+	InventoryId       int64
+	InventoryType     domain.InventoryType
+	InventoryUserName *string
+	TotalSkus         int64
+	TotalQuantity     float64
+	ZeroQuantityItems int64
+}

--- a/src/application/service/test_helpers_test.go
+++ b/src/application/service/test_helpers_test.go
@@ -251,6 +251,8 @@ type stubInventoryRepository struct {
 	getByIdErr    error
 	getPrimary    domain.Inventory
 	getPrimaryErr error
+	getSummary    []output.GetInventorySummaryOutput
+	getSummaryErr error
 }
 
 func (s *stubInventoryRepository) Create(ctx context.Context, inventory domain.Inventory) (int64, error) {
@@ -275,6 +277,10 @@ func (s *stubInventoryRepository) GetAll(ctx context.Context) ([]domain.Inventor
 
 func (s *stubInventoryRepository) GetByUserId(ctx context.Context, userId int64) (domain.Inventory, error) {
 	return s.getByUser, s.getByUserErr
+}
+
+func (s *stubInventoryRepository) GetSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error) {
+	return s.getSummary, s.getSummaryErr
 }
 
 type stubInventoryItemRepository struct {

--- a/src/application/usecase/inventory_usecase/do_transaction_test.go
+++ b/src/application/usecase/inventory_usecase/do_transaction_test.go
@@ -346,6 +346,10 @@ func (r *doTxInventoryRepository) GetPrimaryInventory(ctx context.Context) (doma
 	return domain.Inventory{}, nil
 }
 
+func (r *doTxInventoryRepository) GetSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error) {
+	return nil, nil
+}
+
 type doTxInventoryItemRepository struct {
 	items          map[int64][]domain.InventoryItem
 	createdItems   []domain.InventoryItem

--- a/src/application/usecase/sales_usecase/sales_usecase_test.go
+++ b/src/application/usecase/sales_usecase/sales_usecase_test.go
@@ -174,6 +174,10 @@ func (f *fakeInventoryRepository) GetPrimaryInventory(context.Context) (domain.I
 	return f.primary, f.primaryErr
 }
 
+func (f *fakeInventoryRepository) GetSummary(context.Context) ([]serviceOutput.GetInventorySummaryOutput, error) {
+	return nil, nil
+}
+
 type fakeInventoryItemRepository struct {
 	items    []domain.InventoryItem
 	itemsErr error

--- a/src/infrastructure/repository/inventory_repository.go
+++ b/src/infrastructure/repository/inventory_repository.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bncunha/erp-api/src/application/constants"
 	"github.com/bncunha/erp-api/src/application/errors"
+	"github.com/bncunha/erp-api/src/application/service/output"
 	"github.com/bncunha/erp-api/src/domain"
 )
 
@@ -19,6 +20,7 @@ type InventoryRepository interface {
 	GetAll(ctx context.Context) ([]domain.Inventory, error)
 	GetByUserId(ctx context.Context, userId int64) (domain.Inventory, error)
 	GetPrimaryInventory(ctx context.Context) (domain.Inventory, error)
+	GetSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error)
 }
 
 type inventoryRepository struct {
@@ -90,9 +92,9 @@ func (r *inventoryRepository) GetByUserId(ctx context.Context, userId int64) (do
 	var inventory domain.Inventory
 
 	query := `SELECT i.id, u.id, u.name, i.tenant_id, i.type
-	FROM inventories i
-	LEFT JOIN users u ON u.id = i.user_id
-	WHERE i.user_id = $1 AND i.deleted_at IS NULL AND i.tenant_id = $2 ORDER BY i.id ASC`
+        FROM inventories i
+        LEFT JOIN users u ON u.id = i.user_id
+        WHERE i.user_id = $1 AND i.deleted_at IS NULL AND i.tenant_id = $2 ORDER BY i.id ASC`
 	err := r.db.QueryRowContext(ctx, query, userId, ctx.Value(constants.TENANT_KEY)).Scan(&inventory.Id, &inventory.User.Id, &inventory.User.Name, &inventory.TenantId, &inventory.Type)
 	if err != nil {
 		if errors.IsNoRowsFinded(err) {
@@ -107,8 +109,8 @@ func (r *inventoryRepository) GetPrimaryInventory(ctx context.Context) (domain.I
 	var inventory domain.Inventory
 
 	query := `SELECT i.id, i.tenant_id, i.type
-	FROM inventories i
-	WHERE i.deleted_at IS NULL AND i.tenant_id = $1 AND i.type = $2 ORDER BY i.id ASC`
+        FROM inventories i
+        WHERE i.deleted_at IS NULL AND i.tenant_id = $1 AND i.type = $2 ORDER BY i.id ASC`
 	err := r.db.QueryRowContext(ctx, query, ctx.Value(constants.TENANT_KEY), domain.InventoryTypePrimary).Scan(&inventory.Id, &inventory.TenantId, &inventory.Type)
 	if err != nil {
 		if errors.IsNoRowsFinded(err) {
@@ -117,4 +119,48 @@ func (r *inventoryRepository) GetPrimaryInventory(ctx context.Context) (domain.I
 		return inventory, err
 	}
 	return inventory, nil
+}
+
+func (r *inventoryRepository) GetSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error) {
+	tenantId := ctx.Value(constants.TENANT_KEY)
+	summaries := make([]output.GetInventorySummaryOutput, 0)
+
+	query := `SELECT i.id,
+       i.type,
+       u.name,
+       COUNT(DISTINCT ii.sku_id) AS total_skus,
+       COALESCE(SUM(ii.quantity), 0) AS total_quantity,
+       COALESCE(SUM(CASE WHEN ii.quantity = 0 THEN 1 ELSE 0 END), 0) AS zero_quantity_items
+FROM inventories i
+LEFT JOIN users u ON u.id = i.user_id
+LEFT JOIN inventory_items ii ON ii.inventory_id = i.id AND ii.deleted_at IS NULL AND ii.tenant_id = i.tenant_id
+WHERE i.tenant_id = $1 AND i.deleted_at IS NULL
+GROUP BY i.id, i.type, u.name
+ORDER BY i.id ASC`
+
+	rows, err := r.db.QueryContext(ctx, query, tenantId)
+	if err != nil {
+		return summaries, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var summary output.GetInventorySummaryOutput
+		var inventoryType string
+		var userName sql.NullString
+
+		if err := rows.Scan(&summary.InventoryId, &inventoryType, &userName, &summary.TotalSkus, &summary.TotalQuantity, &summary.ZeroQuantityItems); err != nil {
+			return summaries, err
+		}
+
+		summary.InventoryType = domain.InventoryType(inventoryType)
+		if userName.Valid {
+			name := userName.String
+			summary.InventoryUserName = &name
+		}
+
+		summaries = append(summaries, summary)
+	}
+
+	return summaries, nil
 }


### PR DESCRIPTION
## Summary
- add repository, service, and view model plumbing for inventory summaries
- expose a GET /inventory/summary API that reports SKU counts, stock, and zero-quantity totals per inventory
- update test doubles to satisfy the expanded inventory repository interface

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f94456df58832b8d7869579c2d0993