### PR TITLE
Include inventory id in summary view model

### DIFF
--- a/src/api/viewmodel/inventory_viewmodel.go
+++ b/src/api/viewmodel/inventory_viewmodel.go
@@ -144,6 +144,7 @@ func ToGetInventoriesViewModel(inventory domain.Inventory) GetInventoriesViewMod
 }
 
 type GetInventorySummaryViewModel struct {
+	InventoryId       int64   `json:"inventory_id"`
 	InventoryName     string  `json:"inventory_name"`
 	TotalSkus         int64   `json:"total_skus"`
 	TotalQuantity     float64 `json:"total_quantity"`
@@ -157,6 +158,7 @@ func ToGetInventorySummaryViewModel(summary output.GetInventorySummaryOutput) Ge
 	}
 
 	return GetInventorySummaryViewModel{
+		InventoryId:       summary.InventoryId,
 		InventoryName:     inventoryName,
 		TotalSkus:         summary.TotalSkus,
 		TotalQuantity:     summary.TotalQuantity,


### PR DESCRIPTION
## Summary
- add the inventory identifier to the inventory summary view model
- map the identifier from the service output so /inventory/summary exposes it

## Testing
- go test ./... *(fails: command hangs due to external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68fa2d585b90832b9d9deff204afc483