### PR TITLE
Add inventory summary by id endpoint

### DIFF
--- a/src/api/controllers/inventory_controller.go
+++ b/src/api/controllers/inventory_controller.go
@@ -104,3 +104,14 @@ func (c *InventoryController) GetInventoriesSummary(context echo.Context) error 
 
 	return context.JSON(_http.StatusOK, summaryViewModels)
 }
+
+func (c *InventoryController) GetInventorySummary(context echo.Context) error {
+	id := helper.ParseInt64(context.Param("id"))
+
+	summary, err := c.inventoryService.GetInventorySummaryById(context.Request().Context(), id)
+	if err != nil {
+		return context.JSON(_http.StatusBadRequest, http.HandleError(err))
+	}
+
+	return context.JSON(_http.StatusOK, viewmodel.ToGetInventorySummaryByIdViewModel(summary))
+}

--- a/src/api/router.go
+++ b/src/api/router.go
@@ -92,6 +92,7 @@ func (r *router) setupPrivateRoutes() {
 	inventoryGroup := private.Group("/inventory", middleware.RoleMiddleware([]domain.Role{domain.UserRoleAdmin}))
 	inventoryGroup.GET("", r.controller.InventoryController.GetAllInventories)
 	inventoryGroup.GET("/summary", r.controller.InventoryController.GetInventoriesSummary)
+	inventoryGroup.GET("/:id/summary", r.controller.InventoryController.GetInventorySummary)
 	inventoryGroup.GET("/:id/items", r.controller.InventoryController.GetInventoryItemsByInventoryId)
 	inventoryGroup.GET("/items", r.controller.InventoryController.GetAllInventoryItems)
 	inventoryGroup.GET("/transaction", r.controller.InventoryController.GetAllInventoryTransactions)

--- a/src/api/viewmodel/inventory_viewmodel.go
+++ b/src/api/viewmodel/inventory_viewmodel.go
@@ -165,3 +165,24 @@ func ToGetInventorySummaryViewModel(summary output.GetInventorySummaryOutput) Ge
 		ZeroQuantityItems: summary.ZeroQuantityItems,
 	}
 }
+
+type GetInventorySummaryByIdViewModel struct {
+	InventoryId       int64   `json:"inventory_id"`
+	InventoryName     string  `json:"inventory_name"`
+	TotalQuantity     float64 `json:"total_quantity"`
+	ZeroQuantityItems int64   `json:"zero_quantity_items"`
+}
+
+func ToGetInventorySummaryByIdViewModel(summary output.GetInventorySummaryByIdOutput) GetInventorySummaryByIdViewModel {
+	inventoryName := inventoryTypeMap[summary.InventoryType]
+	if summary.InventoryUserName != nil && *summary.InventoryUserName != "" {
+		inventoryName = *summary.InventoryUserName + " - " + inventoryName
+	}
+
+	return GetInventorySummaryByIdViewModel{
+		InventoryId:       summary.InventoryId,
+		InventoryName:     inventoryName,
+		TotalQuantity:     summary.TotalQuantity,
+		ZeroQuantityItems: summary.ZeroQuantityItems,
+	}
+}

--- a/src/application/service/inventory_service.go
+++ b/src/application/service/inventory_service.go
@@ -22,6 +22,7 @@ type InventoryService interface {
 	GetAllInventoryTransactions(ctx context.Context) ([]output.GetInventoryTransactionsOutput, error)
 	GetAllInventories(ctx context.Context) ([]domain.Inventory, error)
 	GetInventoriesSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error)
+	GetInventorySummaryById(ctx context.Context, id int64) (output.GetInventorySummaryByIdOutput, error)
 }
 
 type inventoryService struct {
@@ -97,4 +98,8 @@ func (s *inventoryService) GetAllInventories(ctx context.Context) ([]domain.Inve
 
 func (s *inventoryService) GetInventoriesSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error) {
 	return s.inventoryRepository.GetSummary(ctx)
+}
+
+func (s *inventoryService) GetInventorySummaryById(ctx context.Context, id int64) (output.GetInventorySummaryByIdOutput, error) {
+	return s.inventoryRepository.GetSummaryById(ctx, id)
 }

--- a/src/application/service/inventory_service_test.go
+++ b/src/application/service/inventory_service_test.go
@@ -77,6 +77,17 @@ func TestInventoryServiceGetInventoriesSummary(t *testing.T) {
 	}
 }
 
+func TestInventoryServiceGetInventorySummaryById(t *testing.T) {
+	expected := output.GetInventorySummaryByIdOutput{InventoryId: 1}
+	repo := &stubInventoryRepository{getSummaryById: expected}
+	service := &inventoryService{inventoryRepository: repo}
+
+	summary, err := service.GetInventorySummaryById(context.Background(), 1)
+	if err != nil || summary.InventoryId != expected.InventoryId {
+		t.Fatalf("unexpected summary by id result")
+	}
+}
+
 func TestInventoryServiceDoTransactionValidationError(t *testing.T) {
 	service := &inventoryService{}
 	if err := service.DoTransaction(context.Background(), request.CreateInventoryTransactionRequest{}); err == nil {

--- a/src/application/service/output/inventory_output.go
+++ b/src/application/service/output/inventory_output.go
@@ -43,3 +43,11 @@ type GetInventorySummaryOutput struct {
 	TotalQuantity     float64
 	ZeroQuantityItems int64
 }
+
+type GetInventorySummaryByIdOutput struct {
+	InventoryId       int64
+	InventoryType     domain.InventoryType
+	InventoryUserName *string
+	TotalQuantity     float64
+	ZeroQuantityItems int64
+}

--- a/src/application/service/test_helpers_test.go
+++ b/src/application/service/test_helpers_test.go
@@ -241,18 +241,20 @@ func (s *stubUserRepository) GetByUsername(ctx context.Context, username string)
 }
 
 type stubInventoryRepository struct {
-	createErr     error
-	created       domain.Inventory
-	getAll        []domain.Inventory
-	getAllErr     error
-	getByUser     domain.Inventory
-	getByUserErr  error
-	getById       domain.Inventory
-	getByIdErr    error
-	getPrimary    domain.Inventory
-	getPrimaryErr error
-	getSummary    []output.GetInventorySummaryOutput
-	getSummaryErr error
+	createErr         error
+	created           domain.Inventory
+	getAll            []domain.Inventory
+	getAllErr         error
+	getByUser         domain.Inventory
+	getByUserErr      error
+	getById           domain.Inventory
+	getByIdErr        error
+	getPrimary        domain.Inventory
+	getPrimaryErr     error
+	getSummary        []output.GetInventorySummaryOutput
+	getSummaryErr     error
+	getSummaryById    output.GetInventorySummaryByIdOutput
+	getSummaryByIdErr error
 }
 
 func (s *stubInventoryRepository) Create(ctx context.Context, inventory domain.Inventory) (int64, error) {
@@ -281,6 +283,10 @@ func (s *stubInventoryRepository) GetByUserId(ctx context.Context, userId int64)
 
 func (s *stubInventoryRepository) GetSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error) {
 	return s.getSummary, s.getSummaryErr
+}
+
+func (s *stubInventoryRepository) GetSummaryById(ctx context.Context, id int64) (output.GetInventorySummaryByIdOutput, error) {
+	return s.getSummaryById, s.getSummaryByIdErr
 }
 
 type stubInventoryItemRepository struct {

--- a/src/application/usecase/inventory_usecase/do_transaction_test.go
+++ b/src/application/usecase/inventory_usecase/do_transaction_test.go
@@ -350,6 +350,10 @@ func (r *doTxInventoryRepository) GetSummary(ctx context.Context) ([]output.GetI
 	return nil, nil
 }
 
+func (r *doTxInventoryRepository) GetSummaryById(ctx context.Context, id int64) (output.GetInventorySummaryByIdOutput, error) {
+	return output.GetInventorySummaryByIdOutput{}, nil
+}
+
 type doTxInventoryItemRepository struct {
 	items          map[int64][]domain.InventoryItem
 	createdItems   []domain.InventoryItem

--- a/src/application/usecase/sales_usecase/sales_usecase_test.go
+++ b/src/application/usecase/sales_usecase/sales_usecase_test.go
@@ -178,6 +178,10 @@ func (f *fakeInventoryRepository) GetSummary(context.Context) ([]serviceOutput.G
 	return nil, nil
 }
 
+func (f *fakeInventoryRepository) GetSummaryById(context.Context, int64) (serviceOutput.GetInventorySummaryByIdOutput, error) {
+	return serviceOutput.GetInventorySummaryByIdOutput{}, nil
+}
+
 type fakeInventoryItemRepository struct {
 	items    []domain.InventoryItem
 	itemsErr error


### PR DESCRIPTION
## Summary
- add repository and service support to fetch a single inventory summary
- expose GET /inventory/:id/summary with a dedicated view model
- update tests and stubs to cover the new repository contract

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fa5942c54c832bb7d17c42d214d8d6