### PR TITLE
Add last transaction days to inventory summary

### DIFF
--- a/src/api/viewmodel/inventory_viewmodel.go
+++ b/src/api/viewmodel/inventory_viewmodel.go
@@ -169,6 +169,7 @@ func ToGetInventorySummaryViewModel(summary output.GetInventorySummaryOutput) Ge
 type GetInventorySummaryByIdViewModel struct {
 	InventoryId         int64   `json:"inventory_id"`
 	InventoryName       string  `json:"inventory_name"`
+	TotalSkus           int64   `json:"total_skus"`
 	TotalQuantity       float64 `json:"total_quantity"`
 	ZeroQuantityItems   int64   `json:"zero_quantity_items"`
 	LastTransactionDays *int64  `json:"last_transaction_days"`
@@ -183,6 +184,7 @@ func ToGetInventorySummaryByIdViewModel(summary output.GetInventorySummaryByIdOu
 	return GetInventorySummaryByIdViewModel{
 		InventoryId:         summary.InventoryId,
 		InventoryName:       inventoryName,
+		TotalSkus:           summary.TotalSkus,
 		TotalQuantity:       summary.TotalQuantity,
 		ZeroQuantityItems:   summary.ZeroQuantityItems,
 		LastTransactionDays: summary.LastTransactionDays,

--- a/src/api/viewmodel/inventory_viewmodel.go
+++ b/src/api/viewmodel/inventory_viewmodel.go
@@ -167,10 +167,11 @@ func ToGetInventorySummaryViewModel(summary output.GetInventorySummaryOutput) Ge
 }
 
 type GetInventorySummaryByIdViewModel struct {
-	InventoryId       int64   `json:"inventory_id"`
-	InventoryName     string  `json:"inventory_name"`
-	TotalQuantity     float64 `json:"total_quantity"`
-	ZeroQuantityItems int64   `json:"zero_quantity_items"`
+	InventoryId         int64   `json:"inventory_id"`
+	InventoryName       string  `json:"inventory_name"`
+	TotalQuantity       float64 `json:"total_quantity"`
+	ZeroQuantityItems   int64   `json:"zero_quantity_items"`
+	LastTransactionDays *int64  `json:"last_transaction_days"`
 }
 
 func ToGetInventorySummaryByIdViewModel(summary output.GetInventorySummaryByIdOutput) GetInventorySummaryByIdViewModel {
@@ -180,9 +181,10 @@ func ToGetInventorySummaryByIdViewModel(summary output.GetInventorySummaryByIdOu
 	}
 
 	return GetInventorySummaryByIdViewModel{
-		InventoryId:       summary.InventoryId,
-		InventoryName:     inventoryName,
-		TotalQuantity:     summary.TotalQuantity,
-		ZeroQuantityItems: summary.ZeroQuantityItems,
+		InventoryId:         summary.InventoryId,
+		InventoryName:       inventoryName,
+		TotalQuantity:       summary.TotalQuantity,
+		ZeroQuantityItems:   summary.ZeroQuantityItems,
+		LastTransactionDays: summary.LastTransactionDays,
 	}
 }

--- a/src/application/service/output/inventory_output.go
+++ b/src/application/service/output/inventory_output.go
@@ -48,6 +48,7 @@ type GetInventorySummaryByIdOutput struct {
 	InventoryId         int64
 	InventoryType       domain.InventoryType
 	InventoryUserName   *string
+	TotalSkus           int64
 	TotalQuantity       float64
 	ZeroQuantityItems   int64
 	LastTransactionDays *int64

--- a/src/application/service/output/inventory_output.go
+++ b/src/application/service/output/inventory_output.go
@@ -45,9 +45,10 @@ type GetInventorySummaryOutput struct {
 }
 
 type GetInventorySummaryByIdOutput struct {
-	InventoryId       int64
-	InventoryType     domain.InventoryType
-	InventoryUserName *string
-	TotalQuantity     float64
-	ZeroQuantityItems int64
+	InventoryId         int64
+	InventoryType       domain.InventoryType
+	InventoryUserName   *string
+	TotalQuantity       float64
+	ZeroQuantityItems   int64
+	LastTransactionDays *int64
 }

--- a/src/infrastructure/repository/inventory_repository.go
+++ b/src/infrastructure/repository/inventory_repository.go
@@ -175,6 +175,7 @@ func (r *inventoryRepository) GetSummaryById(ctx context.Context, id int64) (out
 	query := `SELECT i.id,
    i.type,
    u.name,
+   COUNT(DISTINCT ii.sku_id) AS total_skus,
    COALESCE(SUM(ii.quantity), 0) AS total_quantity,
    COALESCE(SUM(CASE WHEN ii.quantity = 0 THEN 1 ELSE 0 END), 0) AS zero_quantity_items,
    (
@@ -192,7 +193,7 @@ GROUP BY i.id, i.type, u.name`
 
 	var lastTransactionDays sql.NullInt64
 
-	err := r.db.QueryRowContext(ctx, query, id, tenantId).Scan(&summary.InventoryId, &inventoryType, &userName, &summary.TotalQuantity, &summary.ZeroQuantityItems, &lastTransactionDays)
+	err := r.db.QueryRowContext(ctx, query, id, tenantId).Scan(&summary.InventoryId, &inventoryType, &userName, &summary.TotalSkus, &summary.TotalQuantity, &summary.ZeroQuantityItems, &lastTransactionDays)
 	if err != nil {
 		if errors.IsNoRowsFinded(err) {
 			return summary, ErrInventoryNotFound


### PR DESCRIPTION
## Summary
- compute the last inventory transaction age in the summary-by-id repository query
- expose the last_transaction_days value through the service output and API view model

## Testing
- go test ./... *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68fa80014a88832bad0f7fa4c3a1e987