### PR TITLE
Use frontend URL in welcome email

### DIFF
--- a/migrations/006-companies-addresses.sql
+++ b/migrations/006-companies-addresses.sql
@@ -1,0 +1,21 @@
+ALTER TABLE companies ADD COLUMN cnpj VARCHAR(18);
+ALTER TABLE companies ADD COLUMN cpf VARCHAR(14);
+ALTER TABLE companies ADD COLUMN cellphone VARCHAR(20);
+ALTER TABLE companies ADD COLUMN legal_name VARCHAR(255);
+
+CREATE UNIQUE INDEX companies_cnpj_unique ON companies (cnpj) WHERE cnpj IS NOT NULL;
+CREATE UNIQUE INDEX companies_cpf_unique ON companies (cpf) WHERE cpf IS NOT NULL;
+
+CREATE TABLE addresses (
+  id BIGSERIAL PRIMARY KEY,
+  street VARCHAR(255) NOT NULL,
+  neighborhood VARCHAR(255) NOT NULL,
+  number VARCHAR(50) NOT NULL,
+  city VARCHAR(255) NOT NULL,
+  uf CHAR(2) NOT NULL,
+  cep VARCHAR(20) NOT NULL,
+  tenant_id BIGINT NOT NULL REFERENCES companies(id),
+  created_at TIMESTAMP DEFAULT NOW() NOT NULL
+);
+
+CREATE UNIQUE INDEX addresses_tenant_id_unique ON addresses (tenant_id);

--- a/src/api/controllers/company_controller.go
+++ b/src/api/controllers/company_controller.go
@@ -1,0 +1,31 @@
+package controller
+
+import (
+    _http "net/http"
+
+    "github.com/bncunha/erp-api/src/api/http"
+    request "github.com/bncunha/erp-api/src/api/requests"
+    "github.com/bncunha/erp-api/src/application/service"
+    "github.com/labstack/echo/v4"
+)
+
+type CompanyController struct {
+    companyService service.CompanyService
+}
+
+func NewCompanyController(companyService service.CompanyService) *CompanyController {
+    return &CompanyController{companyService}
+}
+
+func (c *CompanyController) Create(context echo.Context) error {
+    var companyRequest request.CreateCompanyRequest
+    if err := context.Bind(&companyRequest); err != nil {
+        return context.JSON(_http.StatusBadRequest, http.HandleError(err))
+    }
+
+    if err := c.companyService.Create(context.Request().Context(), companyRequest); err != nil {
+        return context.JSON(_http.StatusBadRequest, http.HandleError(err))
+    }
+
+    return context.JSON(_http.StatusCreated, nil)
+}

--- a/src/api/controllers/controllers.go
+++ b/src/api/controllers/controllers.go
@@ -12,6 +12,7 @@ type Controller struct {
 	InventoryController *InventoryController
 	SalesController     *SalesController
 	CustomerController  *CustomerController
+	CompanyController   *CompanyController
 }
 
 func NewController(services *service.ApplicationService) *Controller {
@@ -29,4 +30,5 @@ func (c *Controller) SetupControllers() {
 	c.InventoryController = NewInventoryController(c.services.InventoryService)
 	c.SalesController = NewSalesController(c.services.SalesService)
 	c.CustomerController = NewCustomerController(c.services.CustomerService)
+	c.CompanyController = NewCompanyController(c.services.CompanyService)
 }

--- a/src/api/requests/company_request.go
+++ b/src/api/requests/company_request.go
@@ -1,0 +1,62 @@
+package request
+
+import (
+	"github.com/bncunha/erp-api/src/application/errors"
+	helper "github.com/bncunha/erp-api/src/application/helpers"
+	"github.com/bncunha/erp-api/src/application/validator"
+)
+
+type CreateCompanyRequest struct {
+	Name      string                   `json:"name" validate:"required,max=255"`
+	LegalName string                   `json:"legal_name" validate:"required,max=255"`
+	Cnpj      string                   `json:"cnpj" validate:"omitempty,max=20"`
+	Cpf       string                   `json:"cpf" validate:"omitempty,max=14"`
+	Cellphone string                   `json:"cellphone" validate:"required,max=20"`
+	Address   CreateCompanyAddress     `json:"address" validate:"required"`
+	User      CreateCompanyUserRequest `json:"user" validate:"required"`
+}
+
+type CreateCompanyAddress struct {
+	Street       string `json:"street" validate:"required,max=255"`
+	Neighborhood string `json:"neighborhood" validate:"required,max=255"`
+	Number       string `json:"number" validate:"required,max=50"`
+	City         string `json:"city" validate:"required,max=255"`
+	UF           string `json:"uf" validate:"required,len=2"`
+	Cep          string `json:"cep" validate:"required,max=20"`
+}
+
+type CreateCompanyUserRequest struct {
+	Name        string `json:"name" validate:"required,max=100"`
+	Username    string `json:"username" validate:"required,max=30"`
+	PhoneNumber string `json:"phone_number" validate:"max=20"`
+	Email       string `json:"email" validate:"required,email,max=250"`
+	Password    string `json:"password" validate:"required,min=6"`
+}
+
+func (r *CreateCompanyRequest) Validate() error {
+	if err := validator.Validate(r); err != nil {
+		return err
+	}
+
+	hasCnpj := r.Cnpj != ""
+	hasCpf := r.Cpf != ""
+	if hasCnpj == hasCpf {
+		return errors.New("Envie apenas CPF ou CNPJ.")
+	}
+
+	if hasCnpj {
+		if !helper.IsValidCNPJ(r.Cnpj) {
+			return errors.New("CNPJ inválido")
+		}
+		r.Cnpj = helper.SanitizeDocument(r.Cnpj)
+	}
+
+	if hasCpf {
+		if !helper.IsValidCPF(r.Cpf) {
+			return errors.New("CPF inválido")
+		}
+		r.Cpf = helper.SanitizeDocument(r.Cpf)
+	}
+
+	return nil
+}

--- a/src/api/router.go
+++ b/src/api/router.go
@@ -52,6 +52,7 @@ func (r *router) setupPublicRoutes() {
 	r.echo.POST("/login", r.controller.AuthController.Login)
 	r.echo.POST("/forgot-password", r.controller.UserController.ForgotPassword)
 	r.echo.POST("/change-password", r.controller.UserController.ChangePassword)
+	r.echo.POST("/signup", r.controller.CompanyController.Create)
 	r.echo.GET("/health", func(c echo.Context) error {
 		return c.String(http.StatusOK, "Hello, World!")
 	})

--- a/src/application/helpers/document_validator.go
+++ b/src/application/helpers/document_validator.go
@@ -1,0 +1,84 @@
+package helper
+
+import "strings"
+
+func cleanNumeric(value string) string {
+    replacer := strings.NewReplacer(".", "", "-", "", "/", "", " ", "", ",", "")
+    return replacer.Replace(value)
+}
+
+func IsValidCPF(cpf string) bool {
+    cpf = cleanNumeric(cpf)
+    if len(cpf) != 11 {
+        return false
+    }
+
+    invalid := []string{"00000000000", "11111111111", "22222222222", "33333333333", "44444444444", "55555555555", "66666666666", "77777777777", "88888888888", "99999999999"}
+    for _, inv := range invalid {
+        if cpf == inv {
+            return false
+        }
+    }
+
+    sum := 0
+    for i := 0; i < 9; i++ {
+        sum += int(cpf[i]-'0') * (10 - i)
+    }
+    firstDigit := (sum * 10) % 11
+    if firstDigit == 10 {
+        firstDigit = 0
+    }
+    if firstDigit != int(cpf[9]-'0') {
+        return false
+    }
+
+    sum = 0
+    for i := 0; i < 10; i++ {
+        sum += int(cpf[i]-'0') * (11 - i)
+    }
+    secondDigit := (sum * 10) % 11
+    if secondDigit == 10 {
+        secondDigit = 0
+    }
+    return secondDigit == int(cpf[10]-'0')
+}
+
+func IsValidCNPJ(cnpj string) bool {
+    cnpj = cleanNumeric(cnpj)
+    if len(cnpj) != 14 {
+        return false
+    }
+
+    invalid := []string{"00000000000000", "11111111111111", "22222222222222", "33333333333333", "44444444444444", "55555555555555", "66666666666666", "77777777777777", "88888888888888", "99999999999999"}
+    for _, inv := range invalid {
+        if cnpj == inv {
+            return false
+        }
+    }
+
+    weights1 := []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+    weights2 := []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+
+    calcDigit := func(numbers string, weights []int) int {
+        sum := 0
+        for i, w := range weights {
+            sum += int(numbers[i]-'0') * w
+        }
+        remainder := sum % 11
+        if remainder < 2 {
+            return 0
+        }
+        return 11 - remainder
+    }
+
+    firstDigit := calcDigit(cnpj[:12], weights1)
+    if firstDigit != int(cnpj[12]-'0') {
+        return false
+    }
+    secondDigit := calcDigit(cnpj[:13], weights2)
+    return secondDigit == int(cnpj[13]-'0')
+}
+
+func SanitizeDocument(doc string) string {
+    return cleanNumeric(doc)
+}

--- a/src/application/helpers/document_validator_test.go
+++ b/src/application/helpers/document_validator_test.go
@@ -1,0 +1,28 @@
+package helper
+
+import "testing"
+
+func TestIsValidCPF(t *testing.T) {
+	if !IsValidCPF("390.533.447-05") {
+		t.Fatalf("expected valid cpf")
+	}
+	if IsValidCPF("111.111.111-11") {
+		t.Fatalf("expected invalid cpf")
+	}
+}
+
+func TestIsValidCNPJ(t *testing.T) {
+	if !IsValidCNPJ("04.252.011/0001-10") {
+		t.Fatalf("expected valid cnpj")
+	}
+	if IsValidCNPJ("11.111.111/1111-11") {
+		t.Fatalf("expected invalid cnpj")
+	}
+}
+
+func TestSanitizeDocument(t *testing.T) {
+	sanitized := SanitizeDocument("04.252.011/0001-10")
+	if sanitized != "04252011000110" {
+		t.Fatalf("unexpected sanitize result: %s", sanitized)
+	}
+}

--- a/src/application/service/company_service.go
+++ b/src/application/service/company_service.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+
+	request "github.com/bncunha/erp-api/src/api/requests"
+	"github.com/bncunha/erp-api/src/application/constants"
+	"github.com/bncunha/erp-api/src/application/errors"
+	emailusecase "github.com/bncunha/erp-api/src/application/usecase/email_usecase"
+	"github.com/bncunha/erp-api/src/domain"
+	"github.com/bncunha/erp-api/src/infrastructure/logs"
+)
+
+type CompanyService interface {
+	Create(ctx context.Context, request request.CreateCompanyRequest) error
+}
+
+type companyService struct {
+	companyRepository domain.CompanyRepository
+	addressRepository domain.AddressRepository
+	inventoryRepo     domain.InventoryRepository
+	userRepository    domain.UserRepository
+	encrypto          domain.Encrypto
+	emailUsecase      emailusecase.EmailUseCase
+	txManager         transactionManager
+}
+
+func NewCompanyService(companyRepository domain.CompanyRepository, addressRepository domain.AddressRepository, inventoryRepo domain.InventoryRepository, userRepository domain.UserRepository, encrypto domain.Encrypto, emailUsecase emailusecase.EmailUseCase, txManager transactionManager) CompanyService {
+	return &companyService{companyRepository, addressRepository, inventoryRepo, userRepository, encrypto, emailUsecase, txManager}
+}
+
+func (s *companyService) Create(ctx context.Context, req request.CreateCompanyRequest) (err error) {
+	if err = req.Validate(); err != nil {
+		return err
+	}
+
+	tx, err := s.txManager.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+		}
+	}()
+
+	companyId, err := s.companyRepository.CreateWithTx(ctx, tx, domain.Company{
+		Name:      req.Name,
+		LegalName: req.LegalName,
+		Cnpj:      req.Cnpj,
+		Cpf:       req.Cpf,
+		Cellphone: req.Cellphone,
+	})
+	if err != nil {
+		if errors.IsDuplicated(err) {
+			return errors.New("Empresa já cadastrada")
+		}
+		return err
+	}
+
+	_, err = s.addressRepository.CreateWithTx(ctx, tx, domain.Address{
+		Street:       req.Address.Street,
+		Neighborhood: req.Address.Neighborhood,
+		Number:       req.Address.Number,
+		City:         req.Address.City,
+		UF:           req.Address.UF,
+		Cep:          req.Address.Cep,
+		TenantId:     companyId,
+	})
+	if err != nil {
+		return err
+	}
+
+	ctxWithTenant := context.WithValue(ctx, constants.TENANT_KEY, companyId)
+
+	adminUser := domain.NewUser(domain.CreateUserParams{
+		Username:    req.User.Username,
+		Name:        req.User.Name,
+		PhoneNumber: req.User.PhoneNumber,
+		Role:        string(domain.UserRoleAdmin),
+		Email:       req.User.Email,
+	})
+
+	encryptedPassword, err := s.encrypto.Encrypt(req.User.Password)
+	if err != nil {
+		return err
+	}
+	adminUser.Password = encryptedPassword
+
+	adminId, err := s.userRepository.CreateWithTx(ctxWithTenant, tx, adminUser)
+	if err != nil {
+		if errors.IsDuplicated(err) {
+			return errors.ParseDuplicatedMessage("Usuário", err)
+		}
+		return err
+	}
+
+	adminUser.Id = adminId
+	adminUser.TenantId = companyId
+
+	_, err = s.inventoryRepo.CreateWithTx(ctxWithTenant, tx, domain.Inventory{TenantId: companyId, User: domain.User{Id: adminUser.Id}, Type: domain.InventoryTypePrimary})
+	if err != nil {
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return err
+	}
+
+	go func() {
+		welcomeErr := s.emailUsecase.SendWelcome(ctx, req.User.Email, req.User.Name)
+		if welcomeErr != nil {
+			logs.Logger.Errorf("Erro ao enviar email de boas vindas para o usuário %s: %v", req.User.Username, welcomeErr)
+		}
+	}()
+
+	return nil
+}

--- a/src/application/service/company_service_test.go
+++ b/src/application/service/company_service_test.go
@@ -1,0 +1,235 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	request "github.com/bncunha/erp-api/src/api/requests"
+	"github.com/bncunha/erp-api/src/application/service/output"
+	"github.com/bncunha/erp-api/src/domain"
+)
+
+type stubCompanyRepository struct {
+	id  int64
+	err error
+}
+
+func (s *stubCompanyRepository) CreateWithTx(ctx context.Context, tx *sql.Tx, company domain.Company) (int64, error) {
+	return s.id, s.err
+}
+
+type stubAddressRepository struct {
+	err error
+}
+
+func (s *stubAddressRepository) CreateWithTx(ctx context.Context, tx *sql.Tx, address domain.Address) (int64, error) {
+	return 1, s.err
+}
+
+type stubCompanyInventoryRepository struct {
+	input domain.Inventory
+	err   error
+}
+
+func (s *stubCompanyInventoryRepository) Create(ctx context.Context, inventory domain.Inventory) (int64, error) {
+	return 0, nil
+}
+
+func (s *stubCompanyInventoryRepository) CreateWithTx(ctx context.Context, tx *sql.Tx, inventory domain.Inventory) (int64, error) {
+	s.input = inventory
+	return 1, s.err
+}
+
+func (s *stubCompanyInventoryRepository) GetById(ctx context.Context, id int64) (domain.Inventory, error) {
+	return domain.Inventory{}, nil
+}
+
+func (s *stubCompanyInventoryRepository) GetAll(ctx context.Context) ([]domain.Inventory, error) {
+	return nil, nil
+}
+
+func (s *stubCompanyInventoryRepository) GetByUserId(ctx context.Context, userId int64) (domain.Inventory, error) {
+	return domain.Inventory{}, nil
+}
+
+func (s *stubCompanyInventoryRepository) GetPrimaryInventory(ctx context.Context) (domain.Inventory, error) {
+	return domain.Inventory{}, nil
+}
+
+func (s *stubCompanyInventoryRepository) GetSummary(ctx context.Context) ([]output.GetInventorySummaryOutput, error) {
+	return nil, nil
+}
+
+func (s *stubCompanyInventoryRepository) GetSummaryById(ctx context.Context, id int64) (output.GetInventorySummaryByIdOutput, error) {
+	return output.GetInventorySummaryByIdOutput{}, nil
+}
+
+type stubCompanyUserRepository struct {
+	createdUser domain.User
+	id          int64
+	err         error
+}
+
+func (s *stubCompanyUserRepository) GetByUsername(ctx context.Context, username string) (domain.User, error) {
+	return domain.User{}, nil
+}
+
+func (s *stubCompanyUserRepository) Create(ctx context.Context, user domain.User) (int64, error) {
+	s.createdUser = user
+	if s.id == 0 {
+		s.id = 10
+	}
+	return s.id, s.err
+}
+
+func (s *stubCompanyUserRepository) CreateWithTx(ctx context.Context, tx *sql.Tx, user domain.User) (int64, error) {
+	return s.Create(ctx, user)
+}
+
+func (s *stubCompanyUserRepository) Update(ctx context.Context, user domain.User) error { return nil }
+func (s *stubCompanyUserRepository) Inactivate(ctx context.Context, id int64) error     { return nil }
+func (s *stubCompanyUserRepository) GetAll(ctx context.Context, input domain.GetAllUserInput) ([]domain.User, error) {
+	return nil, nil
+}
+func (s *stubCompanyUserRepository) GetById(ctx context.Context, id int64) (domain.User, error) {
+	return domain.User{}, nil
+}
+func (s *stubCompanyUserRepository) UpdatePassword(ctx context.Context, user domain.User, newPassword string) error {
+	return nil
+}
+func (s *stubCompanyUserRepository) GetByEmail(ctx context.Context, email string) (domain.User, error) {
+	return domain.User{}, nil
+}
+
+type stubCompanyTxManager struct {
+	tx  *sql.Tx
+	err error
+}
+
+func (s *stubCompanyTxManager) BeginTx(ctx context.Context) (*sql.Tx, error) {
+	return s.tx, s.err
+}
+
+type stubWelcomeEmailUseCase struct {
+	toEmail string
+	toName  string
+	err     error
+}
+
+func (s *stubWelcomeEmailUseCase) SendInvite(ctx context.Context, user domain.User, code string, uuid string) error {
+	return nil
+}
+
+func (s *stubWelcomeEmailUseCase) SendRecoverPassword(ctx context.Context, user domain.User, code string, uuid string) error {
+	return nil
+}
+
+func (s *stubWelcomeEmailUseCase) SendWelcome(ctx context.Context, email string, name string) error {
+	s.toEmail = email
+	s.toName = name
+	return s.err
+}
+
+func newFakeTransaction() (*sql.Tx, *fakeSQLTx) {
+	driverName := fmt.Sprintf("fakedriver-%d", time.Now().UnixNano())
+	sql.Register(driverName, &fakeDriver{tx: &fakeSQLTx{}})
+	db, _ := sql.Open(driverName, "")
+	tx, _ := db.Begin()
+	return tx, db.Driver().(*fakeDriver).tx
+}
+
+func TestCompanyServiceCreateSuccess(t *testing.T) {
+	tx, fakeTx := newFakeTransaction()
+	userRepo := &stubCompanyUserRepository{}
+	inventoryRepo := &stubCompanyInventoryRepository{}
+	emailUsecase := &stubWelcomeEmailUseCase{}
+	service := NewCompanyService(&stubCompanyRepository{id: 5}, &stubAddressRepository{}, inventoryRepo, userRepo, &stubEncrypto{}, emailUsecase, &stubCompanyTxManager{tx: tx})
+
+	err := service.Create(context.Background(), request.CreateCompanyRequest{
+		Name:      "Empresa",
+		LegalName: "Empresa Ltda",
+		Cpf:       "390.533.447-05",
+		Cellphone: "11999999999",
+		Address: request.CreateCompanyAddress{
+			Street:       "Rua A",
+			Neighborhood: "Centro",
+			Number:       "123",
+			City:         "Cidade",
+			UF:           "SP",
+			Cep:          "00000000",
+		},
+		User: request.CreateCompanyUserRequest{
+			Name:        "Admin",
+			Username:    "admin",
+			PhoneNumber: "123",
+			Email:       "admin@test.com",
+			Password:    "secret123",
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if !fakeTx.committed || fakeTx.rolledBack {
+		t.Fatalf("transaction not committed correctly: %+v", fakeTx)
+	}
+	if userRepo.createdUser.TenantId != 0 || userRepo.createdUser.Username != "admin" {
+		t.Fatalf("expected admin user to be created, got %+v", userRepo.createdUser)
+	}
+	if userRepo.createdUser.Password != "encrypted:secret123" {
+		t.Fatalf("expected password to be encrypted, got %s", userRepo.createdUser.Password)
+	}
+	if inventoryRepo.input.User.Id != userRepo.id || inventoryRepo.input.Type != domain.InventoryTypePrimary {
+		t.Fatalf("expected primary inventory to be created for user %d", userRepo.id)
+	}
+	if emailUsecase.toEmail != "admin@test.com" || emailUsecase.toName != "Admin" {
+		t.Fatalf("expected welcome email to be triggered")
+	}
+}
+
+func TestCompanyServiceCreateDuplicate(t *testing.T) {
+	tx, fakeTx := newFakeTransaction()
+	service := NewCompanyService(&stubCompanyRepository{err: fmt.Errorf("duplicate key value violates unique constraint")}, &stubAddressRepository{}, &stubCompanyInventoryRepository{}, &stubCompanyUserRepository{}, &stubEncrypto{}, &stubWelcomeEmailUseCase{}, &stubCompanyTxManager{tx: tx})
+
+	err := service.Create(context.Background(), request.CreateCompanyRequest{
+		Name:      "Empresa",
+		LegalName: "Empresa Ltda",
+		Cnpj:      "04.252.011/0001-10",
+		Cellphone: "11999999999",
+		Address:   request.CreateCompanyAddress{Street: "Rua", Neighborhood: "Centro", Number: "1", City: "Cidade", UF: "SP", Cep: "00000000"},
+		User:      request.CreateCompanyUserRequest{Name: "Admin", Username: "admin", Email: "admin@test.com", Password: "secret123"},
+	})
+
+	if err == nil || err.Error() != "Empresa já cadastrada" {
+		t.Fatalf("expected duplicate error, got %v", err)
+	}
+	if !fakeTx.rolledBack {
+		t.Fatalf("expected transaction rollback")
+	}
+}
+
+func TestCompanyServiceCreateUserError(t *testing.T) {
+	tx, fakeTx := newFakeTransaction()
+	userRepo := &stubCompanyUserRepository{err: fmt.Errorf("user error")}
+	service := NewCompanyService(&stubCompanyRepository{id: 2}, &stubAddressRepository{}, &stubCompanyInventoryRepository{}, userRepo, &stubEncrypto{}, &stubWelcomeEmailUseCase{}, &stubCompanyTxManager{tx: tx})
+
+	err := service.Create(context.Background(), request.CreateCompanyRequest{
+		Name:      "Empresa",
+		LegalName: "Empresa Ltda",
+		Cpf:       "39053344705",
+		Cellphone: "11999999999",
+		Address:   request.CreateCompanyAddress{Street: "Rua", Neighborhood: "Centro", Number: "1", City: "Cidade", UF: "SP", Cep: "00000000"},
+		User:      request.CreateCompanyUserRequest{Name: "Admin", Username: "admin", Email: "admin@test.com", Password: "secret123"},
+	})
+
+	if err == nil || err.Error() != "user error" {
+		t.Fatalf("expected user error, got %v", err)
+	}
+	if !fakeTx.rolledBack {
+		t.Fatalf("expected rollback on user error")
+	}
+}

--- a/src/application/service/service.go
+++ b/src/application/service/service.go
@@ -15,6 +15,7 @@ type ApplicationService struct {
 	InventoryService InventoryService
 	SalesService     SalesService
 	CustomerService  CustomerService
+	CompanyService   CompanyService
 	UserTokenService UserTokenService
 	repositories     *repository.Repository
 	useCases         *usecase.ApplicationUseCase
@@ -42,4 +43,5 @@ func (s *ApplicationService) SetupServices() {
 	s.InventoryService = NewInventoryService(s.useCases.InventoryUseCase, s.repositories.InventoryItemRepository, s.repositories.InventoryTransactionRepository, s.repositories.InventoryRepository, s.repositories)
 	s.SalesService = NewSalesService(s.useCases.SalesUsecase, s.repositories.SalesRepository)
 	s.CustomerService = NewCustomerService(s.repositories.CustomerRepository)
+	s.CompanyService = NewCompanyService(s.repositories.CompanyRepository, s.repositories.AddressRepository, s.repositories.InventoryRepository, s.repositories.UserRepository, s.ports.Encrypto, s.useCases.EmailUseCase, s.repositories)
 }

--- a/src/application/usecase/email_usecase/email_usecase.go
+++ b/src/application/usecase/email_usecase/email_usecase.go
@@ -11,6 +11,7 @@ import (
 type EmailUseCase interface {
 	SendInvite(ctx context.Context, user domain.User, code string, uuid string) error
 	SendRecoverPassword(ctx context.Context, user domain.User, code string, uuid string) error
+	SendWelcome(ctx context.Context, email string, name string) error
 }
 
 type emailUseCase struct {

--- a/src/application/usecase/email_usecase/email_usecase_test.go
+++ b/src/application/usecase/email_usecase/email_usecase_test.go
@@ -59,3 +59,23 @@ func TestEmailUseCaseSendRecoverPassword(t *testing.T) {
 		t.Fatalf("expected recover link in body, got %s", port.body)
 	}
 }
+
+func TestEmailUseCaseSendWelcome(t *testing.T) {
+	cfg := &config.Config{FRONTEND_URL: "http://frontend"}
+	port := &stubEmailPort{}
+	usecase := NewEmailUseCase(cfg, port)
+
+	if err := usecase.SendWelcome(context.Background(), "user@test.com", "User Test"); err != nil {
+		t.Fatalf("unexpected error sending welcome: %v", err)
+	}
+
+	if port.subject != WelcomeSubject {
+		t.Fatalf("expected welcome subject, got %s", port.subject)
+	}
+	if !strings.Contains(port.body, "User Test") {
+		t.Fatalf("expected name in body, got %s", port.body)
+	}
+	if !strings.Contains(port.body, cfg.FRONTEND_URL) {
+		t.Fatalf("expected frontend url in body, got %s", port.body)
+	}
+}

--- a/src/application/usecase/email_usecase/send_welcome.go
+++ b/src/application/usecase/email_usecase/send_welcome.go
@@ -1,0 +1,16 @@
+package emailusecase
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	WelcomeSubject      = "Trinus | Bem-vindo ao Trinus!"
+	WelcomeBodyTemplate = "<html><body><p>Olá %s,</p><p>Bem-vindo ao Trinus! Sua empresa foi cadastrada com sucesso.</p><p>Faça login com seu usuário para começar a usar a plataforma.</p><p><a href=\"%s\" target=\"_blank\">Acessar a plataforma</a></p><p>Atenciosamente,</p><p>Equipe Trinus</p></body></html>"
+)
+
+func (e *emailUseCase) SendWelcome(ctx context.Context, email string, name string) error {
+	body := fmt.Sprintf(WelcomeBodyTemplate, name, e.config.FRONTEND_URL)
+	return e.emailPort.Send(SenderEmail, SenderName, email, name, WelcomeSubject, body)
+}

--- a/src/application/usecase/inventory_usecase/do_transaction_test.go
+++ b/src/application/usecase/inventory_usecase/do_transaction_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 type stubInventoryItemRepository struct {
-        createdItems          []domain.InventoryItem
-        returnedInventoryItem domain.InventoryItem
+	createdItems          []domain.InventoryItem
+	returnedInventoryItem domain.InventoryItem
 	createErr             error
 	getErr                error
 	updateErr             error
-        getManyErr            error
-        items                 map[int64][]domain.InventoryItem
+	getManyErr            error
+	items                 map[int64][]domain.InventoryItem
 }
 
 func (s *stubInventoryItemRepository) Create(ctx context.Context, tx *sql.Tx, inventoryItem domain.InventoryItem) (int64, error) {
@@ -71,16 +71,16 @@ func (s *stubInventoryItemRepository) GetAll(ctx context.Context) ([]output.GetI
 }
 
 func (s *stubInventoryItemRepository) GetByInventoryId(ctx context.Context, id int64) ([]output.GetInventoryItemsOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 func (s *stubInventoryItemRepository) GetBySkuId(ctx context.Context, skuId int64) ([]domain.GetSkuInventoryOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 type stubInventoryTransactionRepository struct {
-        created []domain.InventoryTransaction
-        err     error
+	created []domain.InventoryTransaction
+	err     error
 }
 
 func (s *stubInventoryTransactionRepository) Create(ctx context.Context, tx *sql.Tx, transaction domain.InventoryTransaction) (int64, error) {
@@ -96,11 +96,11 @@ func (s *stubInventoryTransactionRepository) GetAll(ctx context.Context) ([]outp
 }
 
 func (s *stubInventoryTransactionRepository) GetByInventoryId(ctx context.Context, inventoryId int64) ([]output.GetInventoryTransactionsOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 func (s *stubInventoryTransactionRepository) GetBySkuId(ctx context.Context, skuId int64) ([]output.GetInventoryTransactionsOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 func TestNewInventoryUseCase(t *testing.T) {
@@ -391,6 +391,10 @@ func (r *doTxInventoryRepository) Create(ctx context.Context, inventory domain.I
 	return 0, nil
 }
 
+func (r *doTxInventoryRepository) CreateWithTx(ctx context.Context, tx *sql.Tx, inventory domain.Inventory) (int64, error) {
+	return r.Create(ctx, inventory)
+}
+
 func (r *doTxInventoryRepository) GetById(ctx context.Context, id int64) (domain.Inventory, error) {
 	if inv, ok := r.inventories[id]; ok {
 		return inv, nil
@@ -460,11 +464,11 @@ func (r *doTxInventoryItemRepository) GetAll(ctx context.Context) ([]output.GetI
 }
 
 func (r *doTxInventoryItemRepository) GetByInventoryId(ctx context.Context, id int64) ([]output.GetInventoryItemsOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 func (r *doTxInventoryItemRepository) GetBySkuId(ctx context.Context, skuId int64) ([]domain.GetSkuInventoryOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 type doTxInventoryTransactionRepository struct {
@@ -477,11 +481,11 @@ func (r *doTxInventoryTransactionRepository) Create(ctx context.Context, tx *sql
 }
 
 func (r *doTxInventoryTransactionRepository) GetAll(ctx context.Context) ([]output.GetInventoryTransactionsOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 func (r *doTxInventoryTransactionRepository) GetBySkuId(ctx context.Context, skuId int64) ([]output.GetInventoryTransactionsOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 func (r *doTxInventoryTransactionRepository) GetByInventoryId(ctx context.Context, inventoryId int64) ([]output.GetInventoryTransactionsOutput, error) {

--- a/src/application/usecase/sales_usecase/sales_usecase_test.go
+++ b/src/application/usecase/sales_usecase/sales_usecase_test.go
@@ -80,6 +80,9 @@ func (f *fakeUserRepository) GetByUsername(context.Context, string) (domain.User
 }
 
 func (f *fakeUserRepository) Create(context.Context, domain.User) (int64, error) { return 0, nil }
+func (f *fakeUserRepository) CreateWithTx(context.Context, *sql.Tx, domain.User) (int64, error) {
+	return 0, nil
+}
 
 func (f *fakeUserRepository) Update(context.Context, domain.User) error { return nil }
 
@@ -165,6 +168,10 @@ func (f *fakeInventoryRepository) Create(context.Context, domain.Inventory) (int
 	return 0, nil
 }
 
+func (f *fakeInventoryRepository) CreateWithTx(ctx context.Context, tx *sql.Tx, inventory domain.Inventory) (int64, error) {
+	return f.Create(ctx, inventory)
+}
+
 func (f *fakeInventoryRepository) GetById(context.Context, int64) (domain.Inventory, error) {
 	return domain.Inventory{}, nil
 }
@@ -220,11 +227,11 @@ func (f *fakeInventoryItemRepository) GetAll(context.Context) ([]serviceOutput.G
 }
 
 func (f *fakeInventoryItemRepository) GetByInventoryId(context.Context, int64) ([]serviceOutput.GetInventoryItemsOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 func (f *fakeInventoryItemRepository) GetBySkuId(context.Context, int64) ([]domain.GetSkuInventoryOutput, error) {
-        return nil, nil
+	return nil, nil
 }
 
 type fakeSalesRepository struct {

--- a/src/domain/address.go
+++ b/src/domain/address.go
@@ -1,0 +1,12 @@
+package domain
+
+type Address struct {
+    Id          int64
+    Street      string
+    Neighborhood string
+    Number      string
+    City        string
+    UF          string
+    Cep         string
+    TenantId    int64
+}

--- a/src/domain/address_repository.go
+++ b/src/domain/address_repository.go
@@ -1,0 +1,10 @@
+package domain
+
+import (
+    "context"
+    "database/sql"
+)
+
+type AddressRepository interface {
+    CreateWithTx(ctx context.Context, tx *sql.Tx, address Address) (int64, error)
+}

--- a/src/domain/company.go
+++ b/src/domain/company.go
@@ -1,5 +1,11 @@
 package domain
 
 type Company struct {
-	Name string
+	Id        int64
+	Name      string
+	LegalName string
+	Cnpj      string
+	Cpf       string
+	Cellphone string
+	Address   *Address
 }

--- a/src/domain/company_repository.go
+++ b/src/domain/company_repository.go
@@ -1,0 +1,10 @@
+package domain
+
+import (
+    "context"
+    "database/sql"
+)
+
+type CompanyRepository interface {
+    CreateWithTx(ctx context.Context, tx *sql.Tx, company Company) (int64, error)
+}

--- a/src/domain/inventory_repository.go
+++ b/src/domain/inventory_repository.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 )
 
@@ -28,6 +29,7 @@ type GetInventorySummaryByIdOutput struct {
 
 type InventoryRepository interface {
 	Create(ctx context.Context, inventory Inventory) (int64, error)
+	CreateWithTx(ctx context.Context, tx *sql.Tx, inventory Inventory) (int64, error)
 	GetById(ctx context.Context, id int64) (Inventory, error)
 	GetAll(ctx context.Context) ([]Inventory, error)
 	GetByUserId(ctx context.Context, userId int64) (Inventory, error)

--- a/src/domain/user_repository.go
+++ b/src/domain/user_repository.go
@@ -1,6 +1,9 @@
 package domain
 
-import "context"
+import (
+	"context"
+	"database/sql"
+)
 
 type GetAllUserInput struct {
 	Role *Role
@@ -9,6 +12,7 @@ type GetAllUserInput struct {
 type UserRepository interface {
 	GetByUsername(ctx context.Context, username string) (User, error)
 	Create(ctx context.Context, user User) (int64, error)
+	CreateWithTx(ctx context.Context, tx *sql.Tx, user User) (int64, error)
 	Update(ctx context.Context, user User) error
 	Inactivate(ctx context.Context, id int64) error
 	GetAll(ctx context.Context, input GetAllUserInput) ([]User, error)

--- a/src/infrastructure/repository/address_repository.go
+++ b/src/infrastructure/repository/address_repository.go
@@ -1,0 +1,26 @@
+package repository
+
+import (
+    "context"
+    "database/sql"
+
+    "github.com/bncunha/erp-api/src/domain"
+)
+
+type addressRepository struct {
+    db *sql.DB
+}
+
+func NewAddressRepository(db *sql.DB) domain.AddressRepository {
+    return &addressRepository{db}
+}
+
+func (r *addressRepository) CreateWithTx(ctx context.Context, tx *sql.Tx, address domain.Address) (int64, error) {
+    query := `INSERT INTO addresses (street, neighborhood, number, city, uf, cep, tenant_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`
+    var id int64
+    err := tx.QueryRowContext(ctx, query, address.Street, address.Neighborhood, address.Number, address.City, address.UF, address.Cep, address.TenantId).Scan(&id)
+    if err != nil {
+        return id, err
+    }
+    return id, nil
+}

--- a/src/infrastructure/repository/company_repository.go
+++ b/src/infrastructure/repository/company_repository.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+    "context"
+    "database/sql"
+
+    "github.com/bncunha/erp-api/src/domain"
+)
+
+type companyRepository struct {
+    db *sql.DB
+}
+
+func NewCompanyRepository(db *sql.DB) domain.CompanyRepository {
+    return &companyRepository{db}
+}
+
+func (r *companyRepository) CreateWithTx(ctx context.Context, tx *sql.Tx, company domain.Company) (int64, error) {
+    query := `INSERT INTO companies (name, legal_name, cnpj, cpf, cellphone) VALUES ($1, $2, $3, $4, $5) RETURNING id`
+    var id int64
+
+    cnpj := sql.NullString{String: company.Cnpj, Valid: company.Cnpj != ""}
+    cpf := sql.NullString{String: company.Cpf, Valid: company.Cpf != ""}
+    cellphone := sql.NullString{String: company.Cellphone, Valid: company.Cellphone != ""}
+    err := tx.QueryRowContext(ctx, query, company.Name, company.LegalName, cnpj, cpf, cellphone).Scan(&id)
+    if err != nil {
+        return id, err
+    }
+    return id, nil
+}

--- a/src/infrastructure/repository/inventory_repository.go
+++ b/src/infrastructure/repository/inventory_repository.go
@@ -26,6 +26,18 @@ func (r *inventoryRepository) Create(ctx context.Context, inventory domain.Inven
 	return insertedID, err
 }
 
+func (r *inventoryRepository) CreateWithTx(ctx context.Context, tx *sql.Tx, inventory domain.Inventory) (int64, error) {
+	tenantId := inventory.TenantId
+	if tenantId == 0 {
+		tenantId = ctx.Value(constants.TENANT_KEY).(int64)
+	}
+
+	var insertedID int64
+	query := `INSERT INTO inventories (user_id, tenant_id, type) VALUES ($1, $2, $3) RETURNING id`
+	err := tx.QueryRowContext(ctx, query, inventory.User.Id, tenantId, inventory.Type).Scan(&insertedID)
+	return insertedID, err
+}
+
 func (r *inventoryRepository) GetById(ctx context.Context, id int64) (domain.Inventory, error) {
 	tenantId := ctx.Value(constants.TENANT_KEY)
 	var inventory domain.Inventory

--- a/src/infrastructure/repository/repository.go
+++ b/src/infrastructure/repository/repository.go
@@ -19,6 +19,8 @@ type Repository struct {
 	InventoryTransactionRepository domain.InventoryTransactionRepository
 	SalesRepository                domain.SalesRepository
 	CustomerRepository             domain.CustomerRepository
+	CompanyRepository              domain.CompanyRepository
+	AddressRepository              domain.AddressRepository
 }
 
 func NewRepository(db *sql.DB) *Repository {
@@ -36,6 +38,8 @@ func (r *Repository) SetupRepositories() {
 	r.InventoryTransactionRepository = NewInventoryTransactionRepository(r.db, r.InventoryItemRepository)
 	r.SalesRepository = NewSalesRepository(r.db)
 	r.CustomerRepository = NewCustomerRepository(r.db)
+	r.CompanyRepository = NewCompanyRepository(r.db)
+	r.AddressRepository = NewAddressRepository(r.db)
 }
 
 func (r *Repository) BeginTx(ctx context.Context) (*sql.Tx, error) {


### PR DESCRIPTION
## Summary
- use the configured frontend URL in the welcome email template instead of a hardcoded link
- ensure welcome email tests assert the platform link comes from configuration

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7f1c381c832b94eb53613815281a)