### PR TITLE
Add https://erp.trinus.app to production CORS allowlist

### DIFF
--- a/src/api/router.go
+++ b/src/api/router.go
@@ -34,7 +34,7 @@ func (r *router) SetupCors(env string) {
 		}))
 	} else {
 		r.echo.Use(_middleware.CORSWithConfig(_middleware.CORSConfig{
-			AllowOrigins: []string{"https://erp-front-production.onrender.com", "https://trinus.app"},
+			AllowOrigins: []string{"https://erp-front-production.onrender.com", "https://trinus.app", "https://erp.trinus.app"},
 			AllowMethods: []string{echo.GET, echo.HEAD, echo.PUT, echo.PATCH, echo.POST, echo.DELETE},
 		}))
 	}


### PR DESCRIPTION
### Motivation
- Allow the production frontend domain to access the API by including the new origin in the CORS allowlist.
- Ensure the API accepts requests from `https://erp.trinus.app` in production deployments.

### Description
- Updated `src/api/router.go` to add `https://erp.trinus.app` to the production `AllowOrigins` slice in `SetupCors`.
- Kept the existing allowed HTTP methods and non-production CORS origins unchanged.
- CORS is still configured via Echo middleware using `_middleware.CORSWithConfig` and `_middleware.CORSConfig`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bb7bcaf60832bab4a79b899efa252)